### PR TITLE
Add 'http_host' env var

### DIFF
--- a/modules/stack/config.tf
+++ b/modules/stack/config.tf
@@ -116,3 +116,11 @@ resource "aws_ssm_parameter" "db_port" {
   value = "${aws_db_instance.default.port}"
   type  = "String"
 }
+
+resource "aws_ssm_parameter" "http_host" {
+  count = "${length(var.chains)}"
+  name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/http_host"
+  value = "${var.prefix}-explorer-${element(keys(var.chains),count.index)}-elb.amazonaws.com"
+  type  = "String"
+}
+


### PR DESCRIPTION
Relates to https://github.com/poanetwork/poa-explorer/issues/435

We need to define the `HTTP_HOST` env var, so we can configure the WebSocket to accepts requests from other machines in the same host.

I'm not entirely sure this is the right place to configure this though.