### PR TITLE
Switch to an Application Load Balancer and remove Classic Load Balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ The infra created, at a high level, is as follows:
 - A VPC containing all of the resources provisioned
 - A public subnet for the app servers, and a private subnet for the database (and Redis for now)
 - An internet gateway to provide internet access for the VPC
-- An ELB which exposes the app server HTTP endpoints to the world
+- An ALB which exposes the app server HTTP endpoints to the world
 - A security group to lock down ingress to the app servers to 80/443 + SSH
-- A security group to allow the ELB to talk to the app servers
+- A security group to allow the ALB to talk to the app servers
 - A security group to allow the app servers access to the database
 - An internal DNS zone
 - A DNS record for the database

--- a/modules/stack/deploy.tf
+++ b/modules/stack/deploy.tf
@@ -24,8 +24,8 @@ resource "aws_codedeploy_deployment_group" "explorer" {
   }
 
   load_balancer_info {
-    elb_info {
-      name = "${var.prefix}-explorer-${element(keys(var.chains),count.index)}-elb"
+    target_group_info {
+      name = "${aws_lb_target_group.explorer.*.name[count.index]}"
     }
   }
 

--- a/modules/stack/hosts.tf
+++ b/modules/stack/hosts.tf
@@ -51,7 +51,7 @@ resource "aws_autoscaling_group" "explorer" {
   launch_configuration = "${aws_launch_configuration.explorer.name}"
   vpc_zone_identifier  = ["${aws_subnet.default.id}"]
   availability_zones   = ["${data.aws_availability_zones.available.names}"]
-  load_balancers       = ["${aws_elb.explorer.*.name[count.index]}"]
+  target_group_arns    = ["${aws_lb_target_group.explorer.*.arn[count.index]}"]
 
   # Health checks are performed by CodeDeploy hooks
   health_check_type = "EC2"

--- a/modules/stack/outputs.tf
+++ b/modules/stack/outputs.tf
@@ -20,7 +20,7 @@ output "codedeploy_bucket_path" {
 
 output "explorer_urls" {
   description = "A map of each chain to the DNS name of its corresponding Explorer instance"
-  value       = "${zipmap(keys(var.chains), aws_elb.explorer.*.dns_name)}"
+  value       = "${zipmap(keys(var.chains), aws_lb.explorer.*.dns_name)}"
 }
 
 output "db_instance_address" {

--- a/modules/stack/security.tf
+++ b/modules/stack/security.tf
@@ -139,10 +139,10 @@ resource "aws_iam_role" "deployer" {
   assume_role_policy = "${data.aws_iam_policy_document.deployer-assume-role-policy.json}"
 }
 
-# A security group for the ELB so it is accessible via the web
-resource "aws_security_group" "elb" {
-  name        = "${var.prefix}-poa-elb"
-  description = "A security group for the app server ELB, so it is accessible via the web"
+# A security group for the ALB so it is accessible via the web
+resource "aws_security_group" "alb" {
+  name        = "${var.prefix}-poa-alb"
+  description = "A security group for the app server ALB, so it is accessible via the web"
   vpc_id      = "${aws_vpc.vpc.id}"
 
   # HTTP from anywhere

--- a/modules/stack/subnets.tf
+++ b/modules/stack/subnets.tf
@@ -13,6 +13,21 @@ resource "aws_subnet" "default" {
   }
 }
 
+## ALB subnet
+resource "aws_subnet" "alb" {
+  vpc_id                  = "${aws_vpc.vpc.id}"
+  cidr_block              = "${var.public_subnet_cidr}"
+  cidr_block              = "${cidrsubnet(var.db_subnet_cidr, 5, 1)}"
+  availability_zone       = "${data.aws_availability_zones.available.names[1]}"
+  map_public_ip_on_launch = true
+
+  tags {
+    name   = "${var.prefix}-default-subnet"
+    prefix = "${var.prefix}"
+    origin = "terraform"
+  }
+}
+
 ## Database subnet
 resource "aws_subnet" "database" {
   count                   = "${length(data.aws_availability_zones.available.names)}"


### PR DESCRIPTION
Fixes #45 

This pull request removes the Classic Load Balancer and adds an Application Load Balancer. This update allows the explorer to utilize Websockets. 

This has been successfully tested. 