### PR TITLE
Adds SSL listener to the Load Balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The infra created, at a high level, is as follows:
 - A VPC containing all of the resources provisioned
 - A public subnet for the app servers, and a private subnet for the database (and Redis for now)
 - An internet gateway to provide internet access for the VPC
-- An ALB which exposes the app server HTTP endpoints to the world
+- An ALB which exposes the app server HTTPS endpoints to the world
 - A security group to lock down ingress to the app servers to 80/443 + SSH
 - A security group to allow the ALB to talk to the app servers
 - A security group to allow the app servers access to the database
@@ -110,7 +110,18 @@ dynamodb_table = "poa-terraform-lock"
 key_name = "sokol-test"
 prefix = "sokol"
 db_password = "qwerty12345"
+db_instance_class = "db.m4.xlarge"
+db_storage = "120"
+alb_ssl_policy = "ELBSecurityPolicy-2016-08"
+alb_certificate_arn = "arn:aws:acm:us-east-1:290379793816:certificate/6d1bab74-fb46-4244-aab2-832bf519ab24"
 ```
+
+- The region should be left at `us-east-1` as some of the other regions fail for different reasons.
+- The `bucket` and `dynamodb_table` can be edited but should have an identical prefix.
+- The `key_name` should start with the `prefix` and can only contain 5 characters and must start with a letter.
+- The `db_password` can be a changed to any alphanumeric value.
+- The `db_instance_class` and `db_storage` are not required but are defaulted to `db.m4.large` and `100`GB respectively.
+- The `alb_ssl_policy` and `alb_certificate_arn` are required in order to force SSL usage.
 
 ## Defining Chains/Adding Chains
 

--- a/main/main.tf
+++ b/main/main.tf
@@ -33,4 +33,7 @@ module "stack" {
   secret_key_base       = "${var.secret_key_base}"
   new_relic_app_name    = "${var.new_relic_app_name}"
   new_relic_license_key = "${var.new_relic_license_key}"
+
+  alb_ssl_policy      = "${var.alb_ssl_policy}"
+  alb_certificate_arn = "${var.alb_certificate_arn}"
 }

--- a/main/variables.tf
+++ b/main/variables.tf
@@ -92,3 +92,14 @@ variable "new_relic_license_key" {
   description = "The license key for talking to New Relic"
   default     = ""
 }
+
+# SSL Certificate configuration
+variable "alb_ssl_policy" {
+  description = "The SSL Policy for the Application Load Balancer"
+  default     = ""
+}
+
+variable "alb_certificate_arn" {
+  description = "The Certificate ARN for the Applicationn Load Balancer Policy"
+  default     = ""
+}

--- a/modules/stack/config.tf
+++ b/modules/stack/config.tf
@@ -116,3 +116,15 @@ resource "aws_ssm_parameter" "db_port" {
   value = "${aws_db_instance.default.port}"
   type  = "String"
 }
+resource "aws_ssm_parameter" "alb_ssl_policy" {
+  count = "${length(var.chains)}"
+  name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/alb_ssl_policy"
+  value = "${var.alb_ssl_policy}"
+  type  = "String"
+}
+resource "aws_ssm_parameter" "alb_certificate_arn" {
+  count = "${length(var.chains)}"
+  name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/alb_certificate_arn"
+  value = "${var.alb_certificate_arn}"
+  type  = "String"
+}

--- a/modules/stack/routing.tf
+++ b/modules/stack/routing.tf
@@ -61,8 +61,10 @@ resource "aws_lb_target_group" "explorer" {
 # The Listener for the ALB
 resource "aws_alb_listener" "alb_listener" {  
   load_balancer_arn = "${aws_lb.explorer.arn}"  
-  port              = 80  
-  protocol          = "HTTP"
+  port              = 443  
+  protocol          = "HTTPS"
+  ssl_policy        = "${var.alb_ssl_policy}"
+  certificate_arn   = "${var.alb_certificate_arn}"
   
   default_action {    
     target_group_arn = "${aws_lb_target_group.explorer.arn}"

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -26,3 +26,5 @@ variable "db_instance_class" {}
 variable "new_relic_app_name" {}
 variable "new_relic_license_key" {}
 variable "secret_key_base" {}
+variable "alb_ssl_policy" {}
+variable "alb_certificate_arn" {}


### PR DESCRIPTION
Fixes #51 

This PR adds a Listener on Port `443` of the Application Load Balancer. 

### Incompatible Changes

- Terraform no longer listens on port `80`. For our usage, we need the Load Balancer to listen on port `443`