### PR TITLE
Increase the size of root_block_device

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ db_instance_class = "db.m4.xlarge"
 db_storage = "120"
 alb_ssl_policy = "ELBSecurityPolicy-2016-08"
 alb_certificate_arn = "arn:aws:acm:us-east-1:290379793816:certificate/6d1bab74-fb46-4244-aab2-832bf519ab24"
+root_block_size = 120
 ```
 
 - The region should be left at `us-east-1` as some of the other regions fail for different reasons.

--- a/main/main.tf
+++ b/main/main.tf
@@ -19,6 +19,7 @@ module "stack" {
   vpc_cidr           = "${var.vpc_cidr}"
   public_subnet_cidr = "${var.public_subnet_cidr}"
   instance_type      = "${var.instance_type}"
+  root_block_size    = "${var.root_block_size}"
   db_subnet_cidr     = "${var.db_subnet_cidr}"
   dns_zone_name      = "${var.dns_zone_name}"
 

--- a/main/variables.tf
+++ b/main/variables.tf
@@ -28,6 +28,11 @@ variable "instance_type" {
   default     = "m5.xlarge"
 }
 
+variable "root_block_size" {
+  description = "The EC2 instance root block size in GB"
+  default     = 8
+}
+
 variable "chains" {
   description = "A map of chain names to urls"
 

--- a/modules/stack/hosts.tf
+++ b/modules/stack/hosts.tf
@@ -30,6 +30,10 @@ resource "aws_launch_configuration" "explorer" {
 
   user_data = "${file("${path.module}/libexec/init.sh")}"
 
+  root_block_device {
+    volume_size = "${var.root_block_size}"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -6,6 +6,7 @@ variable "public_subnet_cidr" {}
 variable "db_subnet_cidr" {}
 variable "dns_zone_name" {}
 variable "instance_type" {}
+variable "root_block_size" {}
 
 variable "chains" {
   default = {}


### PR DESCRIPTION
Fixes #53 

This PR creates a configurable variable to increase the size of the `root_block_device`. By default, this volume is 8GiB but should contain > 100GiB due to `blockscout` not having rotating logs currently. If this variable is not set you should expect to run out of space in 24-48 hours.
