### PR TITLE
update health check endpoint

### DIFF
--- a/modules/stack/routing.tf
+++ b/modules/stack/routing.tf
@@ -53,7 +53,7 @@ resource "aws_lb_target_group" "explorer" {
     unhealthy_threshold = 2    
     timeout             = 15    
     interval            = 30    
-    path                = "/en/blocks"    
+    path                = "/blocks"    
     port                = 4000  
   }
 }


### PR DESCRIPTION
Fixes #56 

With the removal of internationalization from `blockscout` we need to update the health check of the load balancer from `/en/blocks` to `/blocks` to ensure we're hitting the correct endpoint.