### PR TITLE
Configurable ALB listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ You will also need the following information for the installer:
 
 You will need to set up a new AWS account (or subaccount), and then either login
 to that account using the AWS CLI (via `aws configure`) or create a user account
-that you will use for provisioning, and login to that account. The account used
+that you will use for provisioning, and login to that account. Set output format 
+to `json` for the AWS CLI. The account used
 requires full access to all AWS services, as a wide variety of services are used,
 a mostly complete list is as follows:
 
@@ -122,6 +123,7 @@ root_block_size = 120
 - The `key_name` should start with the `prefix` and can only contain 5 characters and must start with a letter.
 - The `db_password` can be a changed to any alphanumeric value.
 - The `db_instance_class` and `db_storage` are not required but are defaulted to `db.m4.large` and `100`GB respectively.
+- If you don't plan to use SSL, set variable `use_ssl = "false"`
 - The `alb_ssl_policy` and `alb_certificate_arn` are required in order to force SSL usage.
 - The `root_block_size` is the amount of storage on your EC2 instance. This value can be adjusted by how frequently logs are rotated. Logs are located in `/opt/app/logs` of your EC2 instance.
 

--- a/bin/infra
+++ b/bin/infra
@@ -295,7 +295,7 @@ EOF
     if [ -z "$SECRET_KEY_BASE" ]; then
         SECRET_KEY_BASE="$(get_config 'secret_key_base')"
         if [ -z "$SECRET_KEY_BASE" ]; then
-            SECRET_KEY_BASE="$(openssl rand -base64 64)"
+            SECRET_KEY_BASE="$(openssl rand -base64 64 | tr -d '\n')"
         fi
     fi
 

--- a/main/main.tf
+++ b/main/main.tf
@@ -45,4 +45,5 @@ module "stack" {
 
   alb_ssl_policy      = "${var.alb_ssl_policy}"
   alb_certificate_arn = "${var.alb_certificate_arn}"
+  use_ssl = "${var.use_ssl}"
 }

--- a/main/variables.tf
+++ b/main/variables.tf
@@ -162,3 +162,8 @@ variable "alb_certificate_arn" {
   description = "The Certificate ARN for the Applicationn Load Balancer Policy"
   default     = ""
 }
+
+variable "use_ssl" {
+  description = "Enable SSL"
+  default = "true"
+}

--- a/main/variables.tf
+++ b/main/variables.tf
@@ -155,12 +155,12 @@ variable "new_relic_license_key" {
 # SSL Certificate configuration
 variable "alb_ssl_policy" {
   description = "The SSL Policy for the Application Load Balancer"
-  default     = ""
+  default     = "ELBSecurityPolicy-2016-08"
 }
 
 variable "alb_certificate_arn" {
   description = "The Certificate ARN for the Applicationn Load Balancer Policy"
-  default     = ""
+  default     = "arn:aws:acm:us-east-1:008312654217:certificate/ce6ec2cb-eba4-4b02-af1d-e77ce8813497"
 }
 
 variable "use_ssl" {

--- a/modules/stack/routing.tf
+++ b/modules/stack/routing.tf
@@ -58,10 +58,24 @@ resource "aws_lb_target_group" "explorer" {
   }
 }
 
-# The Listener for the ALB
-resource "aws_alb_listener" "alb_listener" {  
-  load_balancer_arn = "${aws_lb.explorer.arn}"  
-  port              = 443  
+# The Listener for the ALB (HTTP protocol)
+resource "aws_alb_listener" "alb_listener_http" {
+  count             = "${var.use_ssl == "true" ? 0 : 1}"
+  load_balancer_arn = "${aws_lb.explorer.arn}"
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "forward"
+    target_group_arn = "${aws_lb_target_group.explorer.arn}"
+  }
+}
+
+# The Listener for the ALB (HTTPS protocol)
+resource "aws_alb_listener" "alb_listener_https" {
+  count             = "${var.use_ssl == "true" ? 1 : 0}"
+  load_balancer_arn = "${aws_lb.explorer.arn}"
+  port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "${var.alb_ssl_policy}"
   certificate_arn   = "${var.alb_certificate_arn}"

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -52,3 +52,4 @@ variable "new_relic_license_key" {}
 variable "secret_key_base" {}
 variable "alb_ssl_policy" {}
 variable "alb_certificate_arn" {}
+variable "use_ssl" {}


### PR DESCRIPTION
Makes ALB listener configurable to allow using both `http` and `https`, removes a new line character from generated variable `secret_key_base` that causes error. Also adds  instruction to  use `json` output format for the AWS CLI, because script generates `key pair` and then queries `KeyMaterial` field from the output, but it will be missed for the `text` format for example.