### PR TITLE
Update Systems Manager variables

### DIFF
--- a/modules/stack/config.tf
+++ b/modules/stack/config.tf
@@ -34,20 +34,20 @@ resource "aws_ssm_parameter" "ethereum_jsonrpc_variant" {
 }
 resource "aws_ssm_parameter" "ethereum_url" {
   count = "${length(var.chains)}"
-  name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/ethereum_url"
+  name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/ethereum_jsonrpc_http_url"
   value = "${element(values(var.chains),count.index)}"
   type  = "String"
 }
 
 resource "aws_ssm_parameter" "trace_url" {
   count = "${length(var.chains)}"
-  name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/trace_url"
+  name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/ethereum_jsonrpc_trace_url"
   value = "${element(values(var.chain_trace_endpoint),count.index)}"
   type  = "String"
 }
 resource "aws_ssm_parameter" "ws_url" {
   count = "${length(var.chains)}"
-  name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/ws_url"
+  name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/ethereum_jsonrpc_ws_url"
   value = "${element(values(var.chain_ws_endpoint),count.index)}"
   type  = "String"
 }


### PR DESCRIPTION
Resolves #68 

This change reflects upcoming changes in https://github.com/poanetwork/blockscout/pull/1006 of `blockscout`. 

## Changes
- `ethereum_url` -> `ethereum_jsonrpc_http_url`
- `trace_url` -> `ethereum_jsonrpce_trace_url`
- `ws_url` -> `ethereum_jsonrpc_ws_url`

## Incompatible Changes
For current infrastructure builds, please update the SSM parameters inside AWS in order to reflect the changes in this PR before deploying. You could also manually enter the endpoints into the build prior to uploading to AWS. 