### PR TITLE
Adds pool size as a configurable variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ db_storage = "120"
 alb_ssl_policy = "ELBSecurityPolicy-2016-08"
 alb_certificate_arn = "arn:aws:acm:us-east-1:290379793816:certificate/6d1bab74-fb46-4244-aab2-832bf519ab24"
 root_block_size = 120
+pool_size = 30
 ```
 
 - The region should be left at `us-east-1` as some of the other regions fail for different reasons.
@@ -126,6 +127,7 @@ root_block_size = 120
 - If you don't plan to use SSL, set variable `use_ssl = "false"`
 - The `alb_ssl_policy` and `alb_certificate_arn` are required in order to force SSL usage.
 - The `root_block_size` is the amount of storage on your EC2 instance. This value can be adjusted by how frequently logs are rotated. Logs are located in `/opt/app/logs` of your EC2 instance.
+- The `pool_size` defines the number of connections allowed by the RDS instance.
 
 ## Database Storage Required
 

--- a/main/main.tf
+++ b/main/main.tf
@@ -28,6 +28,7 @@ module "stack" {
   public_subnet_cidr = "${var.public_subnet_cidr}"
   instance_type      = "${var.instance_type}"
   root_block_size    = "${var.root_block_size}"
+  pool_size          = "${var.pool_size}"
   db_subnet_cidr     = "${var.db_subnet_cidr}"
   dns_zone_name      = "${var.dns_zone_name}"
 

--- a/main/variables.tf
+++ b/main/variables.tf
@@ -33,6 +33,11 @@ variable "root_block_size" {
   default     = 8
 }
 
+variable "pool_size" {
+  description = "The number of connections available to the RDS instance"
+  default     = 30
+}
+
 variable "chains" {
   description = "A map of chain names to urls"
   default = {

--- a/modules/stack/config.tf
+++ b/modules/stack/config.tf
@@ -15,7 +15,7 @@ resource "aws_ssm_parameter" "new_relic_license_key" {
 resource "aws_ssm_parameter" "pool_size" {
   count = "${length(var.chains)}"
   name  = "/${var.prefix}/${element(keys(var.chains),count.index)}/pool_size"
-  value = "10"
+  value = "${var.pool_size}"
   type  = "String"
 }
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -7,6 +7,7 @@ variable "db_subnet_cidr" {}
 variable "dns_zone_name" {}
 variable "instance_type" {}
 variable "root_block_size" {}
+variable "pool_size" {}
 
 variable "chain_jsonrpc_variant" {
   default = {}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -9,3 +9,4 @@ db_storage = "120"
 alb_ssl_policy = "ELBSecurityPolicy-2016-08"
 alb_certificate_arn = "arn:aws:acm:us-east-1:290379793816:certificate/6d1bab74-fb46-4244-aab2-832bf519ab24"
 root_block_size = 120
+pool_size = 30


### PR DESCRIPTION
Resolves #59 

This enhancement adds `pool_size`  to the list of configurable variables and also increases the default value from `10` to `30`. 