### PR TITLE
Add C compiler tools

### DIFF
--- a/modules/stack/libexec/init.sh
+++ b/modules/stack/libexec/init.sh
@@ -70,7 +70,10 @@ fi
 if ! which gcc >/dev/null; then
     log "Installing C compiling tools.."
     yum --enablerepo=epel group install -y "Development Tools" >"$LOG"
-    yum --enablerepo=epel install -y libgmp3-dev > "$LOG"
+fi
+if ! which gmp-devel >/dev/null; then
+    log "Installing gmp-devel.."
+    yum --enablerepo=epel install -y gmp-devel >"$LOG"
 fi
 
 log "Determining region this instance is in.."

--- a/modules/stack/libexec/init.sh
+++ b/modules/stack/libexec/init.sh
@@ -67,7 +67,10 @@ if ! which node >/dev/null; then
     log "Installing nodejs.."
     yum --enablerepo=epel install -y nodejs >"$LOG"
 fi
-
+if ! which gcc >/dev/null; then
+    log "Installing C compiling tools.."
+    yum --enablerepo=epel group install -y "Development Tools" >"$LOG"
+fi
 
 log "Determining region this instance is in.."
 REGION="$(curl -s $DYNDATA_URL/instance-identity/document | jq -r '.region')"

--- a/modules/stack/libexec/init.sh
+++ b/modules/stack/libexec/init.sh
@@ -70,6 +70,7 @@ fi
 if ! which gcc >/dev/null; then
     log "Installing C compiling tools.."
     yum --enablerepo=epel group install -y "Development Tools" >"$LOG"
+    yum --enablerepo=epel install -y libgmp3-dev > "$LOG"
 fi
 
 log "Determining region this instance is in.."


### PR DESCRIPTION
Adds C compiler tools necessary to build a dependency for poanetwork/blockscout#1028. I'm not sure what the equivalent packages are for yum but here's what is need for debian:

* autoconf
* build-essential
* libgmp3-dev
* libtool
