### PR TITLE
Update dependencies

### DIFF
--- a/modules/stack/libexec/init.sh
+++ b/modules/stack/libexec/init.sh
@@ -131,13 +131,13 @@ EOF
 
 log "Installing Erlang.."
 
-wget http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_1_general/esl-erlang_21.0.5-1~centos~7_amd64.rpm
+wget http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_1_general/esl-erlang_21.1-1~centos~7_amd64.rpm
 yum install -y wxGTK-devel unixODBC-devel >"$LOG"
-yum install -y esl-erlang_21.0.5-1~centos~7_amd64.rpm >"$LOG"
+yum install -y esl-erlang_21.1-1~centos~7_amd64.rpm >"$LOG"
 
 log "Installing Elixir to /opt/elixir.."
 mkdir -p /opt/elixir
-wget https://github.com/elixir-lang/elixir/releases/download/v1.7.2/Precompiled.zip >"$LOG"
+wget https://github.com/elixir-lang/elixir/releases/download/v1.7.4/Precompiled.zip >"$LOG"
 unzip Precompiled.zip -d /opt/elixir >"$LOG"
 log "Elixir installed successfully!"
 
@@ -186,7 +186,9 @@ log "Creating pgsql database for $CHAIN"
 
 if ! which psql >/dev/null; then
     log "Installing psql.."
-    yum install -y --enablerepo=epel postgresql >"$LOG"
+    yum install -y  https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-redhat10-10-2.noarch.rpm
+    sed -i "s/rhel-\$releasever-\$basearch/rhel-latest-x86_64/g" "/etc/yum.repos.d/pgdg-10-redhat.repo"
+    yum install -y postgresql10 >"$LOG"
 fi
 
 if ! which g++ >/dev/null; then

--- a/modules/stack/rds.tf
+++ b/modules/stack/rds.tf
@@ -1,7 +1,7 @@
 resource "aws_db_instance" "default" {
   identifier             = "${var.prefix}-${var.db_id}"
   engine                 = "postgres"
-  engine_version         = "9.6"
+  engine_version         = "10.5"
   instance_class         = "${var.db_instance_class}"
   storage_type           = "${var.db_storage_type}"
   allocated_storage      = "${var.db_storage}"


### PR DESCRIPTION
These upgrades have all been tested on every chain.

# Changelog

## Upgrading
- Erlang from `21.0.5` to `21.1.1`
- Elixir from `1.7.2` to `1.7.4`
- Postgres on the EC2 instance from `9.2` to `10.5`
- RDS Postgres from `9.6` to `10.5`

## Incompatibility
- Upgrading the RDS from `9.6` to `10.5` cannot be undone. I've tested on `sokol` with an issue on Reltuples for the wallet count. We have an open issue to update this count method in the future. I do not recommend making this upgrade without that BlockScout issue being completed first. 