### PR TITLE
Fix terraform_location variable

### DIFF
--- a/group_vars/blockscout.yml.example
+++ b/group_vars/blockscout.yml.example
@@ -1,5 +1,8 @@
 # BlockScout related variables
 
+## Exact path to the TF binary on your local machine
+terraform_location: "/usr/local/bin/terraform"
+
 ## An address of BlockScout repo to download
 blockscout_repo: https://github.com/poanetwork/blockscout
 


### PR DESCRIPTION
This PR fixes #116 and gets back the `terraform_location` variable to `blockscout.yml.example` file that was deleted by accident.