### PR TITLE
Move terraform variable to correct file

### DIFF
--- a/group_vars/blockscout.yml.example
+++ b/group_vars/blockscout.yml.example
@@ -1,8 +1,5 @@
 # BlockScout related variables
 
-## Exact path to the TF binary on your local machine
-terraform_location: "/usr/local/bin/terraform"
-
 ## An address of BlockScout repo to download
 blockscout_repo: https://github.com/poanetwork/blockscout
 

--- a/group_vars/infrastructure.yml.example
+++ b/group_vars/infrastructure.yml.example
@@ -1,5 +1,8 @@
 # Infrastructure related variables
 
+## Exact path to the TF binary on your local machine
+terraform_location: "/usr/local/bin/terraform"
+
 ## Name of the DynamoDB table where current lease of TF state file will be stored
 dynamodb_table: "poa-terraform-lock"
 


### PR DESCRIPTION
Just noted that terraform location variable was set in blockscout example file, while it is related to infra and should be located at infra example file accordingly. Related to #116.