### PR TITLE
Remove incompatible variable

### DIFF
--- a/roles/main_infra/files/hosts.tf
+++ b/roles/main_infra/files/hosts.tf
@@ -49,7 +49,6 @@ resource "aws_autoscaling_group" "explorer" {
   desired_capacity     = "1"
   launch_configuration = aws_launch_configuration.explorer.name
   vpc_zone_identifier  = [aws_subnet.default.id]
-  availability_zones   = data.aws_availability_zones.available.names
   target_group_arns    = [aws_lb_target_group.explorer[0].arn]
   placement_group      = var.use_placement_group[var.chains[count.index]] == "True" ? "${var.prefix}-${var.chains[count.index]}-explorer-pg" : null
 


### PR DESCRIPTION
There is a bug in TF script that lead to the inconsistent changes being made using script. The solution is, according to the Terraform official docs, to delete one of the `availability_zones` or `vpc_zone_identifier` variables.